### PR TITLE
Correção de Ícones Quebrados no Moodle 4.5 ao Ativar o Modo de Edição

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -203,6 +203,11 @@ div#trailmiddle-column > ul {
     margin-top: 0;
 }
 
+.course-content ul.trailicons li img, img.iconsmall.edit {
+    width: 20px;
+    padding: 3px;
+}
+
 .course-content ul.trailicons li img.info {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
No Moodle 4.5, observamos que as imagens de ícones estão apresentando problemas de exibição ao ativar o modo de edição. Abaixo, uma captura de tela ilustra o problema:
![Screenshot from 2024-10-30 14-11-29](https://github.com/user-attachments/assets/4e9a1f3b-25a7-4578-97b7-94760473a493)

Para resolver essa questão, foi adicionado um CSS que define um tamanho fixo para as imagens. Essa alteração garante que as imagens permaneçam visíveis e não sejam cortadas, assegurando o correto funcionamento do plugin.
![Screenshot from 2024-10-30 14-14-22](https://github.com/user-attachments/assets/fa44ec34-9d27-42cd-8cab-6f3393c2c5b7)
